### PR TITLE
[PR-4] - Criar processo alternativo de upload do sun editor

### DIFF
--- a/src/modules/rpers/infra/http/controllers/UploadImageController.ts
+++ b/src/modules/rpers/infra/http/controllers/UploadImageController.ts
@@ -1,0 +1,15 @@
+import { UploadImageService } from "@modules/rpers/services/UploadImageService";
+import { Request, Response } from "express";
+import { container } from "tsyringe";
+
+export class UploadImageController {
+  async handle(request: Request, response: Response): Promise<Response> {
+    const { filename } = request.file;
+
+    const uploadImageService = container.resolve(UploadImageService);
+
+    const file = await uploadImageService.execute(filename);
+
+    return response.status(201).json(file);
+  }
+}

--- a/src/modules/rpers/infra/http/routes/rpers.routes.ts
+++ b/src/modules/rpers/infra/http/routes/rpers.routes.ts
@@ -11,6 +11,9 @@ import { RemoveRperMemberController } from '../controllers/RemoveRperMemberContr
 import { CreateRperEditResourceController } from '../controllers/CreateRperEditResourceController';
 import { FindRperEditResourceController } from '../controllers/FindRperEditResourceController';
 import { DeleteRperEditResourceController } from '../controllers/DeleteRperEditResourceController';
+import uploadConfig from '@config/upload';
+import multer from 'multer';
+import { UploadImageController } from '../controllers/UploadImageController';
 
 const rpersRouter = Router();
 const rpersController = new RpersController();
@@ -21,6 +24,9 @@ const removeRperMemberController = new RemoveRperMemberController();
 const createRperEditResourceController = new CreateRperEditResourceController();
 const findRperEditResourceController = new FindRperEditResourceController();
 const deleteRperEditResourceController = new DeleteRperEditResourceController();
+const uploadImageController = new UploadImageController();
+
+const upload = multer(uploadConfig);
 
 //Middleware to ensure the user is logged in before listing RPERs and Creating new one.
 rpersRouter.use(ensureAuthenticated);
@@ -121,5 +127,7 @@ rpersRouter.delete(
   }),
   deleteRperEditResourceController.handle,
 );
+
+rpersRouter.post('/images', upload.single('image'), uploadImageController.handle)
 
 export default rpersRouter;

--- a/src/modules/rpers/services/UploadImageService.ts
+++ b/src/modules/rpers/services/UploadImageService.ts
@@ -1,0 +1,16 @@
+import IStorageProvider from "@shared/container/providers/StorageProvider/models/IStorageProvider";
+import { inject, injectable } from "tsyringe";
+
+@injectable()
+export class UploadImageService {
+  constructor(
+    @inject('StorageProvider')
+    private readonly storageProvider: IStorageProvider
+  ) {}
+
+  async execute(filename: string): Promise<string> {
+    const newFile = await this.storageProvider.saveFile(filename);
+
+    return `${process.env.APP_API_URL}/files/${newFile}`;
+  }
+}


### PR DESCRIPTION
## Qual o problema inicial? 📝
https://raulneto90.atlassian.net/browse/PR-4

## Como esse problema foi resolvido? 🤔
- Foi desenvolvido uma rota no backend que recebe a imagem do sun editor e salva no servidor, para exibição do componente no frontend.

## Como testar? 👀
- Inicie o servidor
- Execute a rota `[POST] /rpers/images`, enviando o arquivo que será utilizado.

###### Adicionou uma nova lib ao projeto? ⚙️:
- [ ] Se sim, qual? <!-- Colocar o nome aqui -->
- [X] Não.